### PR TITLE
Fix hex grid layout

### DIFF
--- a/game/script.js
+++ b/game/script.js
@@ -11,7 +11,10 @@ function axialToPixel(q, r) {
 }
 
 function iso(x, y) {
-  return { x: x - y, y: (x + y) / 2 };
+  // The container is already transformed with rotateX to get an
+  // isometric view, so no additional coordinate conversion is
+  // required here.
+  return { x, y };
 }
 
 for (let q = 0; q < GRID_SIZE; q++) {


### PR DESCRIPTION
## Summary
- adjust coordinate transform to avoid double isometric conversion

## Testing
- `node -e "const SIZE=50;let arr=[];for(let q=0;q<5;q++){for(let r=0;r<5;r++){const x=SIZE*Math.sqrt(3)*(q+r/2);const y=SIZE*1.5*r;arr.push([q,r,x,y]);}};console.log(arr);"`

------
https://chatgpt.com/codex/tasks/task_e_6850557732ec8325bd883602eb6d826d