### PR TITLE
Center hex tiles

### DIFF
--- a/game/style.css
+++ b/game/style.css
@@ -23,6 +23,7 @@ body {
   background: white;
   clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
   border: 1px solid #000;
+  transform: translate(-50%, -50%);
 }
 
 .character {


### PR DESCRIPTION
## Summary
- center each hex tile so the character's red dot aligns with its tile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68505683ad54832591be212c6f135a5b